### PR TITLE
Updating node-hid to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hidstream",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Streaming HID events in Node.js",
   "main": "lib/hidstream.js",
   "engines": {
@@ -13,7 +13,7 @@
     "test": "jasmine"
   },
   "dependencies": {
-    "node-hid": "^0.5.1"
+    "node-hid": "^0.7.2"
   },
   "devDependencies": {
     "eslint": "^3.7.1",


### PR DESCRIPTION
Was having issues on Raspbian Stretch trying to bind to devices that the OS detected as a keyboard. Issue is [noted here](https://github.com/node-hid/node-hid/issues/64), and although it doesn't specifically mention a fix, it appears to be solved in newer versions (when running with `sudo`). So this just updates to `node-hid:^0.7.2` and increments the minor version.